### PR TITLE
Add giscus

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,6 +19,17 @@ website:
   page-footer: 
     center: |
       <a  href="https://icons8.com/icon/iibADLuA7AH6/pelican">Pelican</a> icon by <a href="https://icons8.com">Icons8</a>
+  comments: 
+    giscus: 
+      repo: yuenhsu/yuenhsu.github.io
+      repo-id: R_kgDOPZcehw
+      category: General
+      category-id: DIC_kwDOPZceh84Cuzgu
+      mapping: pathname
+      reactions-enabled: true
+      loading: lazy
+      theme: preferred_color_scheme
+      language: en
 
 bibliography: references.bib
 

--- a/index.qmd
+++ b/index.qmd
@@ -3,6 +3,7 @@ pagetitle: "Yu-En Hsu"
 description-meta: "This is where I share things"
 date-meta: "2025-04-20"
 toc: false
+comments: false
 ---
 
 Hi, I am Yu-En. This is where I share my work, findings, and random stuff I discovered, tried, and learnt. I also test new fonts, colours, and layouts becuase CSS is so much fun! 

--- a/posts.qmd
+++ b/posts.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Posts"
 subtitle: "Sharing my solution to very specific issues/questions and other fun things"
+comments: false
 title-block-banner: true
 listing:
   contents: posts

--- a/projects.qmd
+++ b/projects.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Projects"
 subtitle: "Essentially longer posts focusing more on research and writing"
+comments: false
 title-block-banner: true
 listing:
   contents: projects


### PR DESCRIPTION
This pull request introduces the **giscus** comment system to the website, enabling discussions on individual pages.

### Changes Made

* **Configured giscus:** I verified that the repository meets all three requirements for [giscus](https://giscus.app).
* **Updated `_quarto.yml`:** The `comment` and `giscus` settings were added to the project configuration file, following the official [Quarto documentation](https://quarto.org/docs/reference/projects/websites.html#giscus).
* **Disabled comments on specific pages:** To prevent comments from appearing on non-content pages, I've disabled the feature on the **Home**, **About**, and **Listing** pages by adding `comments: false` to their respective YAML headers.
* **Tested the implementation:** After rendering the project locally, I was unable to see the comment feature. However, after publishing, I can confirm that the giscus comment system is working as expected. This behavior is consistent with [this discussion](https://github.com/quarto-dev/quarto-cli/discussions/10868), which suggests giscus only works on a published site.
